### PR TITLE
Update paper title in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
-# Training code for Objective Robustness Failures in Deep Reinforcement Learning
+# Training code for Goal Misgeneralization in Deep Reinforcement Learning
 
 This code is based on a fork of [this repository](https://github.com/joonleesky/train-procgen-pytorch) by Hojoon Lee.
-It includes scripts for training RL agents on [modified procgen environments](https://github.com/JacobPfau/procgenAISC) and producing the figures for the paper [Objective Robustness in Deep Reinforcement Learning](https://arxiv.org/abs/2105.14111).
+It includes scripts for training RL agents on [modified procgen environments](https://github.com/JacobPfau/procgenAISC) and producing the figures for the paper [Goal Misgeneralization in Deep Reinforcement Learning](https://arxiv.org/abs/2105.14111).
 
 
 ## Requirements


### PR DESCRIPTION
Very small QOL fix: Updates the paper title in Readme from the old title ("Objective Robustness Failure" -> "Goal Misgeneralization"). 

Makes things more clear for people looking for the Goal Misgeneralization code, especially those who missed the objective robustness footnote/related work section in the paper. 